### PR TITLE
Add ansible-lint job

### DIFF
--- a/.zuul.yaml
+++ b/.zuul.yaml
@@ -1,0 +1,4 @@
+---
+- job: 
+    name: ansible-lint
+    run: playbooks/ansible-lint/run.yaml

--- a/playbooks/ansible-lint/run.yaml
+++ b/playbooks/ansible-lint/run.yaml
@@ -1,0 +1,4 @@
+---
+- hosts: all
+  roles:
+    - ansible-lint

--- a/roles/ansible-lint/defaults/main.yml
+++ b/roles/ansible-lint/defaults/main.yml
@@ -1,0 +1,3 @@
+---
+# defaults file for ansible-lint
+zuul_work_dir: "{{ zuul.project.src_dir }}"

--- a/roles/ansible-lint/tasks/main.yml
+++ b/roles/ansible-lint/tasks/main.yml
@@ -1,0 +1,24 @@
+---
+# tasks for ansible-lint
+- name: Install python
+  ansible.builtin.include_role:
+    name: "{{ item }}"
+  loop:
+    - ensure-python
+    - ensure-pip
+
+- name: Install ansible-lint
+  ansible.builtin.pip:
+    name: 
+      - ansible-lint
+      - ansible
+    executable: pip3
+
+- name: run ansible-lint
+  ansible.builtin.command:
+    cmd: /usr/bin/python3 -m ansiblelint --nocolor .
+    chdir: "{{ zuul_work_dir }}"
+  register: ansible_lint_output
+  changed_when: false
+  failed_when:
+    - ansible_lint_output.rc != 0 or (6 | extract(ansible_lint_output.stderr_lines | last | split(' '))) | int > 0


### PR DESCRIPTION
For transfering all to zuul we need some more jobs like ansible-lint.

Signed-off-by: Ramona Beermann <ramona.beermann@osism.tech>
