### PR TITLE
Revert "ansible-lint: use ansible-core (#19)"

### DIFF
--- a/roles/ansible-lint/defaults/main.yml
+++ b/roles/ansible-lint/defaults/main.yml
@@ -1,3 +1,3 @@
-# defaults file for ansible-lint
 ---
+# defaults file for ansible-lint
 zuul_work_dir: "{{ zuul.project.src_dir }}"

--- a/roles/ansible-lint/tasks/main.yml
+++ b/roles/ansible-lint/tasks/main.yml
@@ -1,5 +1,5 @@
-# tasks for ansible-lint
 ---
+# tasks for ansible-lint
 - name: Install python
   ansible.builtin.include_role:
     name: "{{ item }}"
@@ -7,10 +7,10 @@
     - ensure-python
     - ensure-pip
 
-- name: Install ansible-core
-  ansible.builtin.pip:
-    name: ansible-core
-    executable: pip3
+- name: Install ansible
+  become: true
+  ansible.builtin.package:
+    name: ansible
 
 - name: Install ansible-lint
   ansible.builtin.pip:


### PR DESCRIPTION
2023-02-22 19:26:41.127126 | TASK [ansible-lint : Run ansible-lint] 2023-02-22 19:26:42.206712 | ubuntu-jammy | Failed to find runtime dependency 'ansible' in PATH 2023-02-22 19:26:42.682139 | ubuntu-jammy | ok: non-zero return code

This reverts commit 2325293e09229e92e166b43291511f196fc6bcc1.