### PR TITLE
ansible-lint: don't use version 6.16.2

### DIFF
--- a/roles/ansible-lint/tasks/main.yml
+++ b/roles/ansible-lint/tasks/main.yml
@@ -38,5 +38,4 @@
   ansible.builtin.command:
     cmd: "/usr/bin/python3 -m ansiblelint --nocolor -R -r {{ zuul_work_dir }}/.ansible-lint-rules"
     chdir: "{{ zuul_work_dir }}"
-  register: ansible_lint_output
   changed_when: false

--- a/roles/ansible-lint/tasks/main.yml
+++ b/roles/ansible-lint/tasks/main.yml
@@ -14,7 +14,7 @@
 
 - name: Install ansible-lint
   ansible.builtin.pip:
-    name: ansible-lint
+    name: ansible-lint!=6.16.2
     executable: pip3
 
 - name: Create .ansible-lint-rules directory

--- a/roles/dcolicense/defaults/main.yml
+++ b/roles/dcolicense/defaults/main.yml
@@ -1,5 +1,5 @@
 ---
-dco_license_failure: |
+dcolicense_failure: |
   One or more commits have not been signed properly using --signoff.
 
   The meaning of a signoff depends on the project, but it typically certifies

--- a/roles/dcolicense/tasks/main.yml
+++ b/roles/dcolicense/tasks/main.yml
@@ -2,7 +2,7 @@
 - name: Developer Certificate of Origin (DCO) license check
   ansible.builtin.shell:
     cmd: |
-      set -e
+      set -eo pipefail
       result=0
       for commit in $(git cherry -v origin/{{ zuul.branch }} HEAD | cut -d " " -f2)
       do
@@ -17,11 +17,11 @@
       exit $result      
     chdir: "{{ zuul_work_dir }}"
     executable: /bin/bash
-  register: _dco
-  failed_when: _dco.rc > 1
+  register: dcolicense_status
+  failed_when: dcolicense_status.rc > 1
   changed_when: false
 
 - name: License check failed
   ansible.builtin.fail:
-    msg: "{{ dco_license_failure }}"
-  when: _dco.rc != 0
+    msg: "{{ dcolicense_failure }}"
+  when: dcolicense_status.rc != 0

--- a/roles/flake8/tasks/main.yml
+++ b/roles/flake8/tasks/main.yml
@@ -16,7 +16,7 @@
   ansible.builtin.find:
     paths: "{{ zuul_work_dir }}"
     pattern: "*.py"
-  register: py_files
+  register: flake8_py_files
 
 - name: Run flake8
   ansible.builtin.shell:
@@ -26,7 +26,7 @@
       python3 -m flake8 {{ file|relpath(zuul_work_dir) }} 2>&1 | tee -a flake8.txt
     chdir: "{{ zuul_work_dir }}"
     executable: /bin/bash
-  loop: "{{ py_files.files|map(attribute='path')|list }}"
+  loop: "{{ flake8_py_files.files|map(attribute='path')|list }}"
   loop_control:
     loop_var: file
   changed_when: false

--- a/roles/hadolint/tasks/main.yml
+++ b/roles/hadolint/tasks/main.yml
@@ -12,7 +12,7 @@
   ansible.builtin.find:
     paths: "{{ zuul_work_dir }}"
     pattern: "Containerfile*,Dockerfile*"
-  register: files
+  register: hadolint_files
 
 - name: Run hadolint
   ansible.builtin.shell:
@@ -22,5 +22,5 @@
       /usr/local/bin/hadolint {{ item|relpath(zuul_work_dir) }} 2>&1 | tee -a hadolint.txt
     chdir: "{{ zuul_work_dir }}"
     executable: /bin/bash
-  loop: "{{ files.files|map(attribute='path')|list }}"
+  loop: "{{ hadolint_files.files|map(attribute='path')|list }}"
   changed_when: false

--- a/roles/yamllint/tasks/main.yml
+++ b/roles/yamllint/tasks/main.yml
@@ -16,7 +16,7 @@
   ansible.builtin.find:
     paths: "{{ zuul_work_dir }}"
     pattern: "*.yml,*.yaml"
-  register: yaml_files
+  register: yamllint_files
 
 - name: Run yamllint
   ansible.builtin.shell:
@@ -26,7 +26,7 @@
       python3 -m yamllint {{ file|relpath(zuul_work_dir) }} 2>&1 | tee -a yamllint.txt
     chdir: "{{ zuul_work_dir }}"
     executable: /bin/bash
-  loop: "{{ yaml_files.files|map(attribute='path')|list }}"
+  loop: "{{ yamllint_files.files|map(attribute='path')|list }}"
   loop_control:
     loop_var: file
   changed_when: false


### PR DESCRIPTION
ansible-lint version 6.16.2 is broken, ignoring exclude_path definitions[0]. Don't use it.

[0] https://github.com/ansible/ansible-lint/issues/3477