### PR TITLE
Pin ansible-lint version

### DIFF
--- a/roles/ansible-lint/tasks/main.yml
+++ b/roles/ansible-lint/tasks/main.yml
@@ -14,7 +14,7 @@
 
 - name: Install ansible-lint
   ansible.builtin.pip:
-    name: ansible-lint!=6.16.2
+    name: ansible-lint==6.16.1
     executable: pip3
 
 - name: Install jmespath


### PR DESCRIPTION
The next ansible-lint release, 6.17.0, still has issues with excluded paths. Let's pin to a known-working release until we have better testing of new releases.