### PR TITLE
Use lowercase names

### DIFF
--- a/.ansible-lint
+++ b/.ansible-lint
@@ -12,4 +12,3 @@ skip_list:
 # If this isn't there our custom rules will only through a warning and wont generate a failure!:
 warn_list:
   - dummy
-

--- a/playbooks/ansible-lint/run.yaml
+++ b/playbooks/ansible-lint/run.yaml
@@ -1,5 +1,5 @@
 ---
-- name: Ansible-lint
+- name: Run ansible-lint
   hosts: all
   roles:
     - ansible-lint

--- a/playbooks/dcolicense/run.yaml
+++ b/playbooks/dcolicense/run.yaml
@@ -1,5 +1,5 @@
 ---
-- name: Dco License
+- name: Run dcolicense
   hosts: all
   roles:
     - dcolicense

--- a/playbooks/devstack/run.yaml
+++ b/playbooks/devstack/run.yaml
@@ -1,5 +1,5 @@
 ---
-- name: Devstack
+- name: Run devstack
   hosts: all
   roles:
     - devstack

--- a/playbooks/flake8/run.yaml
+++ b/playbooks/flake8/run.yaml
@@ -1,5 +1,5 @@
 ---
-- name: Flake8
+- name: Run flake8
   hosts: all
   roles:
     - flake8

--- a/playbooks/hadolint/run.yaml
+++ b/playbooks/hadolint/run.yaml
@@ -1,5 +1,5 @@
 ---
-- name: Hadolint
+- name: Run hadolint
   hosts: all
   roles:
     - hadolint

--- a/playbooks/mypy/run.yaml
+++ b/playbooks/mypy/run.yaml
@@ -1,5 +1,5 @@
 ---
-- name: Mypy
+- name: Run mypy
   hosts: all
   roles:
     - mypy

--- a/playbooks/publish-pypi-package/run.yaml
+++ b/playbooks/publish-pypi-package/run.yaml
@@ -1,5 +1,5 @@
 ---
-- name: Python-package-build
+- name: Run python-package-build
   hosts: all
   roles:
     - python-package-build

--- a/playbooks/yamllint/run.yaml
+++ b/playbooks/yamllint/run.yaml
@@ -1,5 +1,5 @@
 ---
-- name: Yamllint
+- name: Run yamllint
   hosts: all
   roles:
     - yamllint


### PR DESCRIPTION
It is common in Zuul jobs for the names of the jobs to start with a lowercase letter. Therefore, in this repository we ignore the rule that every name must begin with a capital letter.