### PR TITLE
Add publish-pypi-package job

### DIFF
--- a/.ansible-lint
+++ b/.ansible-lint
@@ -1,6 +1,7 @@
 ---
 exclude_paths:
   - .github/
+  - playbooks/publish-pypi-package/post-run.yaml
 use_default_rules: true
 rulesdir:
   - ./.ansible-lint-rules/

--- a/.zuul.yaml
+++ b/.zuul.yaml
@@ -24,6 +24,12 @@
     run: playbooks/mypy/run.yaml
 
 - job:
+    name: publish-pypi-package
+    pre-run: playbooks/publish-pypi-package/pre-run.yaml
+    run: playbooks/publish-pypi-package/run.yaml
+    post-run: playbooks/publish-pypi-package/post-run.yaml
+
+- job:
     name: yamllint
     run: playbooks/yamllint/run.yaml
 

--- a/playbooks/publish-pypi-package/post-run.yaml
+++ b/playbooks/publish-pypi-package/post-run.yaml
@@ -1,0 +1,9 @@
+---
+- name: Publish-pypi-package
+  hosts: all
+  roles:
+    - upload-pypi
+  vars:
+    pypi_info:
+      api_token: "{{ secret.PYPI_API_TOKEN }}"
+    pypi_path: "{{ zuul_work_dir }}/dist"

--- a/playbooks/publish-pypi-package/pre-run.yaml
+++ b/playbooks/publish-pypi-package/pre-run.yaml
@@ -1,0 +1,5 @@
+---
+- name: Prepare-package-build
+  hosts: all
+  roles:
+    - prepare-package-build

--- a/playbooks/publish-pypi-package/run.yaml
+++ b/playbooks/publish-pypi-package/run.yaml
@@ -1,0 +1,5 @@
+---
+- name: Python-package-build
+  hosts: all
+  roles:
+    - python-package-build

--- a/roles/prepare-package-build/README.md
+++ b/roles/prepare-package-build/README.md
@@ -1,0 +1,3 @@
+# Prepare package build
+
+Setup the environment to build and upload a pypi package

--- a/roles/prepare-package-build/defaults/main.yml
+++ b/roles/prepare-package-build/defaults/main.yml
@@ -1,0 +1,4 @@
+---
+# defaults file for prepare-package-build
+zuul_work_dir: "{{ zuul.project.src_dir }}"
+python_venv_dir: "/tmp/venv"

--- a/roles/prepare-package-build/tasks/main.yml
+++ b/roles/prepare-package-build/tasks/main.yml
@@ -1,0 +1,16 @@
+# tasks file for prepare-package-build
+- name: Install Python
+  ansible.builtin.include_role:
+    name: "{{ item }}"
+  loop:
+    - ensure-python
+    - ensure-pip
+
+- name: Install pip modules
+  ansible.builtin.pip:
+    name: "{{ item }}"
+    virtualenv: "{{ python_venv_dir }}"
+    virtualenv_command: 'python3 -m venv'
+  loop:
+    - build
+    - twine

--- a/roles/python-package-build/README.md
+++ b/roles/python-package-build/README.md
@@ -1,0 +1,3 @@
+# Python package build
+
+Build a python package to be uploaded to pypi

--- a/roles/python-package-build/defaults/main.yml
+++ b/roles/python-package-build/defaults/main.yml
@@ -1,0 +1,4 @@
+---
+# defaults file for python-package-build
+zuul_work_dir: "{{ zuul.project.src_dir }}"
+python_venv_dir: "/tmp/venv"

--- a/roles/python-package-build/tasks/main.yml
+++ b/roles/python-package-build/tasks/main.yml
@@ -1,0 +1,12 @@
+# tasks file for python-package-build
+- name: Build Python package
+  ansible.builtin.command:
+    cmd: "{{ python_venv_dir }}/bin/python3 -m build --sdist --wheel --outdir dist/ ."
+    chdir: "{{ zuul_work_dir }}"
+  changed_when: false
+
+- name: Check package metadata
+  ansible.builtin.command:
+    cmd: "{{ python_venv_dir }}/bin/python3 -m twine check dist/*"
+    chdir: "{{ zuul_work_dir }}"
+  changed_when: false


### PR DESCRIPTION
Hi, we added this job to move the build and publish step away from GitHub Actions.

The tasks were already tested and are currently implemented in a playbook in [The Osism Flavor Manager](https://github.com/osism/openstack-flavor-manager/blob/main/playbooks/build-python-package.yml)

[Log Result](https://zuul.services.betacloud.xyz/t/osism/build/a25e101157cb41869ed2b87d4dda4325)

(It is called build-python-package in the flavor Manager repo but the new name is more appropriate)

We plan on using this new job in every repo that publishes pypi packages. The secret token is per pypi project and set in the respective [zuul.yaml](https://github.com/osism/openstack-flavor-manager/blob/main/.zuul.yaml) of the repo.