### PR TITLE
Update build job

### DIFF
--- a/.zuul.yaml
+++ b/.zuul.yaml
@@ -31,6 +31,7 @@
 
 - job:
     name: publish-pypi-package
+    description: publish-pypi-package job provided by OSISM
     pre-run: playbooks/publish-pypi-package/pre-run.yaml
     run: playbooks/publish-pypi-package/run.yaml
     post-run: playbooks/publish-pypi-package/post-run.yaml

--- a/playbooks/publish-pypi-package/post-run.yaml
+++ b/playbooks/publish-pypi-package/post-run.yaml
@@ -6,4 +6,4 @@
   vars:
     pypi_info:
       api_token: "{{ secret.PYPI_API_TOKEN }}"
-    pypi_path: "{{ zuul_work_dir }}/dist"
+    pypi_path: "{{ zuul.project.src_dir }}/dist"


### PR DESCRIPTION
Hi,

The new job _almost_ works it seems. But I missed, that ``{{ zuul_work_dir }}`` will not be known by the upstream ``upload-pypi`` job

Full log here: https://zuul.services.betacloud.xyz/t/osism/build/91878121dd33458984b5438df999b283/console

If there is a more elegant way to make ``{{ zuul_work_dir }}`` known to the role, please let me know.