### PR TITLE
Fix and extend flake8 and yamllint jobs

### DIFF
--- a/.yamllint.yml
+++ b/.yamllint.yml
@@ -1,0 +1,6 @@
+---
+extends: default
+
+rules:
+  comments: enable
+  line-length: disable

--- a/roles/ansible-molecule/defaults/main.yml
+++ b/roles/ansible-molecule/defaults/main.yml
@@ -1,5 +1,5 @@
 ---
-# defaults file for ansible-molecule 
+# defaults file for ansible-molecule
 zuul_work_dir: "{{ zuul.project.src_dir }}"
 ansible_molecule_venv: "$HOME/venv"
 ansible_molecule_ansible_version: "8.4.0"

--- a/roles/dcolicense/defaults/main.yml
+++ b/roles/dcolicense/defaults/main.yml
@@ -5,5 +5,5 @@ dcolicense_failure: |
   The meaning of a signoff depends on the project, but it typically certifies
   that committer has the rights to submit this work under the same license and
   agrees to a Developer Certificate of Origin
-  (see http://developercertificate.org/ for more information).  
+  (see http://developercertificate.org/ for more information).
 zuul_work_dir: "{{ zuul.project.src_dir }}"

--- a/roles/dcolicense/tasks/main.yml
+++ b/roles/dcolicense/tasks/main.yml
@@ -14,7 +14,7 @@
           result=1
         fi
       done
-      exit $result      
+      exit $result
     chdir: "{{ zuul_work_dir }}"
     executable: /bin/bash
   register: dcolicense_status

--- a/roles/flake8/defaults/main.yml
+++ b/roles/flake8/defaults/main.yml
@@ -1,3 +1,4 @@
 ---
 # defaults file for flake8
 zuul_work_dir: "{{ zuul.project.src_dir }}"
+flake8_excludes: [""]

--- a/roles/flake8/tasks/main.yml
+++ b/roles/flake8/tasks/main.yml
@@ -16,6 +16,7 @@
   ansible.builtin.find:
     paths: "{{ zuul_work_dir }}"
     pattern: "*.py"
+    excludes: "{{ flake8_excludes }}"
     recurse: true
   register: flake8_py_files
 

--- a/roles/flake8/tasks/main.yml
+++ b/roles/flake8/tasks/main.yml
@@ -16,6 +16,7 @@
   ansible.builtin.find:
     paths: "{{ zuul_work_dir }}"
     pattern: "*.py"
+    recurse: true
   register: flake8_py_files
 
 - name: Run flake8

--- a/roles/python-package-build/tasks/main.yml
+++ b/roles/python-package-build/tasks/main.yml
@@ -1,3 +1,4 @@
+---
 # tasks file for python-package-build
 - name: Build Python package
   ansible.builtin.command:

--- a/roles/yamllint/defaults/main.yml
+++ b/roles/yamllint/defaults/main.yml
@@ -1,3 +1,4 @@
 ---
 # defaults file for yamllint
 zuul_work_dir: "{{ zuul.project.src_dir }}"
+yamllint_excludes: [""]

--- a/roles/yamllint/tasks/main.yml
+++ b/roles/yamllint/tasks/main.yml
@@ -16,6 +16,7 @@
   ansible.builtin.find:
     paths: "{{ zuul_work_dir }}"
     pattern: "*.yml,*.yaml"
+    excludes: "{{ yamllint_excludes }}"
     recurse: true
   register: yamllint_files
 

--- a/roles/yamllint/tasks/main.yml
+++ b/roles/yamllint/tasks/main.yml
@@ -16,6 +16,7 @@
   ansible.builtin.find:
     paths: "{{ zuul_work_dir }}"
     pattern: "*.yml,*.yaml"
+    recurse: true
   register: yamllint_files
 
 - name: Run yamllint


### PR DESCRIPTION
As described in https://github.com/osism/issues/issues/681 the ``flake8`` and ``yamllint`` jobs do not recurse in folders inside the repository root.

This means that files in sub-folders were not being tested correctly.

This MR enables the ``recurse`` flag for both jobs. It also (in a separate commit) allows to specify an exclude path list, which I imagine, might come in useful later.