### PR TITLE
Add Python-black job

### DIFF
--- a/.zuul.yaml
+++ b/.zuul.yaml
@@ -47,6 +47,11 @@
     post-run: playbooks/publish-pypi-package/post-run.yaml
 
 - job:
+    name: python-black
+    description: python-black job provided by OSISM
+    run: playbooks/python-black/run.yml
+
+- job:
     name: yamllint
     description: yamllint job provided by OSISM
     run: playbooks/yamllint/run.yaml

--- a/playbooks/python-black/run.yml
+++ b/playbooks/python-black/run.yml
@@ -1,0 +1,5 @@
+---
+- name: Install Black and format code
+  hosts: all
+  roles:
+    - python-black

--- a/roles/python-black/README.md
+++ b/roles/python-black/README.md
@@ -1,0 +1,3 @@
+# python-black
+
+Run `python-black` against repository.

--- a/roles/python-black/defaults/main.yml
+++ b/roles/python-black/defaults/main.yml
@@ -1,0 +1,5 @@
+---
+# defaults file for python-black
+python_venv_dir: /tmp
+zuul_work_dir: "{{ zuul.project.src_dir }}"
+black_excluded_dir: ""

--- a/roles/python-black/tasks/main.yml
+++ b/roles/python-black/tasks/main.yml
@@ -1,0 +1,21 @@
+---
+- name: Install Python
+  ansible.builtin.include_role:
+    name: "{{ item }}"
+  loop:
+    - ensure-python
+    - ensure-pip
+
+- name: Install pip module
+  ansible.builtin.pip:
+    name: black
+    state: latest
+    virtualenv: "{{ python_venv_dir }}"
+    virtualenv_command: 'python3 -m venv'
+    # noqa package-latest
+
+- name: Check code with Black
+  ansible.builtin.command:
+    cmd: "{{ python_venv_dir }}/bin/python3 -m black --exclude {{ black_excluded_dir }} --check ."
+    chdir: "{{ zuul_work_dir }}"
+  changed_when: false


### PR DESCRIPTION
Black is a Python tool to auto-format source files.

This implements a test that checks, if any auto-formatting could be performed for a given Repo and fails accordingly.

cf. https://github.com/osism/zuul-jobs/issues/56

The role was tested here: https://github.com/osism/ansible-collection-commons/pull/542