### PR TITLE
ansible-lint: add community.general.pamd

### DIFF
--- a/roles/ansible-lint/files/osism_fqcn_list.yaml
+++ b/roles/ansible-lint/files/osism_fqcn_list.yaml
@@ -246,6 +246,7 @@ community.general:
   - community.general.opennebula
   - community.general.opentelemetry
   - community.general.pam_limits
+  - community.general.pamd
   - community.general.passwordstore
   - community.general.pbrun
   - community.general.pfexec


### PR DESCRIPTION
Related to osism/ansible-collection-commons#582