### PR TITLE
Add CentOS compatibility to ansible-molecule role

### DIFF
--- a/roles/ansible-molecule/defaults/main.yml
+++ b/roles/ansible-molecule/defaults/main.yml
@@ -3,3 +3,4 @@
 zuul_work_dir: "{{ zuul.project.src_dir }}"
 ansible_molecule_venv: "$HOME/venv"
 ansible_molecule_ansible_version: "8.4.0"
+ansible_molecule_python_version_centos: "3.11"

--- a/roles/ansible-molecule/tasks/install-Debian.yml
+++ b/roles/ansible-molecule/tasks/install-Debian.yml
@@ -1,0 +1,14 @@
+---
+- name: Install python and pip
+  ansible.builtin.include_role:
+    name: "{{ item }}"
+  loop:
+    - ensure-python
+    - ensure-pip
+
+- name: Install Ansible
+  ansible.builtin.pip:
+    name: "ansible=={{ ansible_molecule_ansible_version }}"
+    virtualenv: "{{ ansible_molecule_venv }}"
+    virtualenv_command: 'python3 -m venv'
+    state: present

--- a/roles/ansible-molecule/tasks/install-RedHat.yml
+++ b/roles/ansible-molecule/tasks/install-RedHat.yml
@@ -1,0 +1,15 @@
+---
+- name: Install python and pip version {{ ansible_molecule_python_version_centos }}
+  become: true
+  ansible.builtin.package:
+    name:
+      - python{{ ansible_molecule_python_version_centos }}
+      - python{{ ansible_molecule_python_version_centos }}-pip
+    state: present
+
+- name: Install Ansible
+  ansible.builtin.pip:
+    name: "ansible=={{ ansible_molecule_ansible_version }}"
+    virtualenv: "{{ ansible_molecule_venv }}"
+    virtualenv_command: "python{{ ansible_molecule_python_version_centos }} -m venv"
+    state: present

--- a/roles/ansible-molecule/tasks/main.yml
+++ b/roles/ansible-molecule/tasks/main.yml
@@ -1,22 +1,11 @@
 ---
 # tasks file for ansible_molecule
-- name: Install python
-  ansible.builtin.include_role:
-    name: "{{ item }}"
-  loop:
-    - ensure-python
-    - ensure-pip
-
-- name: Install ansible
-  ansible.builtin.pip:
-    name: "ansible=={{ ansible_molecule_ansible_version }}"
-    virtualenv: "{{ ansible_molecule_venv }}"
-    virtualenv_command: 'python3 -m venv'
+- name: Include node specific install tasks
+  ansible.builtin.include_tasks: "install-{{ ansible_os_family }}.yml"
 
 - name: Install requirements
   ansible.builtin.pip:
     virtualenv: "{{ ansible_molecule_venv }}"
-    virtualenv_command: 'python3 -m venv'
     requirements: "molecule/requirements.txt"
     chdir: "{{ zuul_work_dir }}"
 


### PR DESCRIPTION
Enhance the ansible-molecule role to include CentOS compatibility.

cf. https://github.com/osism/issues/issues/844
tested here: https://github.com/osism/ansible-collection-commons/pull/590