### PR TITLE
devstack: Add option to enable fake virt driver for nova

### DIFF
--- a/roles/devstack/defaults/main.yml
+++ b/roles/devstack/defaults/main.yml
@@ -10,3 +10,6 @@ devstack_password: password
 
 # Services to deploy
 devstack_services: "keystone g-api"
+
+# Use this option to enable the nova fake virt driver for testing
+devstack_use_fake_driver: false

--- a/roles/devstack/tasks/main.yml
+++ b/roles/devstack/tasks/main.yml
@@ -64,6 +64,8 @@
       RABBIT_PASSWORD={{ devstack_password }}
       SERVICE_PASSWORD={{ devstack_password }}
 
+      {{ 'VIRT_DRIVER=fake' if (devstack_use_fake_driver) else '' }}
+
       HOST_IP=127.0.0.1
       INSTALL_TEMPEST=False
 


### PR DESCRIPTION
Used in https://github.com/osism/openstack-simple-stress/pull/63

Tested in https://zuul.services.betacloud.xyz/t/osism/build/ebd5dfc6a4ea469088d98951afd6d1d9