### PR TITLE
Add ansible-ensure-readme role

### DIFF
--- a/playbooks/ansible-ensure-readme/run.yaml
+++ b/playbooks/ansible-ensure-readme/run.yaml
@@ -1,0 +1,5 @@
+---
+- name: Run ansible-ensure-readme
+  hosts: all
+  roles:
+    - ansible-ensure-readme

--- a/roles/ansible-ensure-readme/tasks/main.yml
+++ b/roles/ansible-ensure-readme/tasks/main.yml
@@ -1,0 +1,22 @@
+---
+- name: Find all roles
+  ansible.builtin.find:
+    paths: "{{ zuul.project.src_dir }}/roles/"
+    file_type: directory
+  register: role_dirs
+
+- name: Check for README.md in each role
+  ansible.builtin.stat:
+    path: "{{ item.path }}/README.md"
+  register: readme_check
+  loop: "{{ role_dirs.files }}"
+  loop_control:
+    label: "{{ item.path }}"
+
+- name: Fail if any role is missing README.md
+  ansible.builtin.fail:
+    msg: "Missing README.md in role {{ item.item.path }}"
+  when: not item.stat.exists
+  loop: "{{ readme_check.results }}"
+  loop_control:
+    label: "{{ item.item.path }}"


### PR DESCRIPTION
The ansible-ensure-readme role ensures that a README.md is in every single roles directory of an ansible collection.

Based on https://github.com/vexxhost/atmosphere/commit/558c4a613fb0c89f0f5b6bb20ba0f630d3b3cad8