### PR TITLE
Revert "Use Ansible 8 for the hadolint job"

### DIFF
--- a/.zuul.yaml
+++ b/.zuul.yaml
@@ -38,7 +38,6 @@
     name: hadolint
     description: hadolint job provided by OSISM
     run: playbooks/hadolint/run.yaml
-    ansible-version: 8
 
 - job:
     name: mypy


### PR DESCRIPTION
Reverts osism/zuul-jobs#131

The switch to use Ansible 8 has now been made globally for the whole Zuul tenant.