### PR TITLE
devstack: do not use pip

### DIFF
--- a/roles/devstack/tasks/main.yml
+++ b/roles/devstack/tasks/main.yml
@@ -44,8 +44,6 @@
       sudo apt-get install -y --fix-missing \
           erlang \
           rabbitmq-server
-
-      python3 -m pip --no-cache-dir install -U 'pip==23.0.1'
     chdir: "{{ zuul_work_dir }}"
     executable: /bin/bash
   changed_when: false


### PR DESCRIPTION
This will fix the following issue:

To install Python packages system-wide, try apt install python3-xyz, where xyz is the package you are trying to install.