### PR TITLE
Rl update black pin

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -16,7 +16,7 @@
       "fileMatch":[
         "^roles\\/ansible-lint\\/defaults\\/main.yml$",
         "^roles\\/ansible-molecule\\/defaults\\/main.yml$",
-        "^roles\\/black\\/defaults\\/main.yml$",
+        "^roles\\/python-black\\/defaults\\/main.yml$",
         "^roles\\/flake8\\/defaults\\/main.yml$",
         "^roles\\/hadolint\\/defaults\\/main.yml$",
         "^roles\\/mypy\\/defaults\\/main.yml$",

--- a/roles/python-black/defaults/main.yml
+++ b/roles/python-black/defaults/main.yml
@@ -4,5 +4,5 @@ python_venv_dir: /tmp
 zuul_work_dir: "{{ zuul.project.src_dir }}"
 
 # renovate: datasource=pypi depName=black
-black_version: '24.8.0'
+black_version: '26.3.1'
 black_excluded_dir: ""


### PR DESCRIPTION
black has not been updated in a long time.

- update black from 24.8.0 to 26.3.1
- fix the renovate regex to make renovate work for python-black