### PR TITLE
Add ensure-pipenv role

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -16,6 +16,7 @@
       "fileMatch":[
         "^roles\\/ansible-lint\\/defaults\\/main.yml$",
         "^roles\\/ansible-molecule\\/defaults\\/main.yml$",
+        "^roles\\/ensure-pipenv\\/defaults\\/main.yml$",
         "^roles\\/python-black\\/defaults\\/main.yml$",
         "^roles\\/flake8\\/defaults\\/main.yml$",
         "^roles\\/hadolint\\/defaults\\/main.yml$",

--- a/roles/ensure-pipenv/README.md
+++ b/roles/ensure-pipenv/README.md
@@ -1,0 +1,13 @@
+# ensure-pipenv
+
+Installs a pinned version of pipenv into the shared Python venv.
+
+Designed to run after `ensure-pip`, which ensures pip is available
+and sets `ensure_pip_virtualenv_command`.
+
+## Role Variables
+
+| Variable | Default | Description |
+|---|---|---|
+| `python_venv_dir` | `/tmp/venv` | Path to the Python venv |
+| `pipenv_version` | `2026.5.2` | Version of pipenv to install |

--- a/roles/ensure-pipenv/defaults/main.yml
+++ b/roles/ensure-pipenv/defaults/main.yml
@@ -1,0 +1,6 @@
+---
+# defaults file for ensure-pipenv
+python_venv_dir: /tmp/venv
+
+# renovate: datasource=pypi depName=pipenv
+pipenv_version: '2026.5.2'

--- a/roles/ensure-pipenv/tasks/main.yml
+++ b/roles/ensure-pipenv/tasks/main.yml
@@ -1,0 +1,6 @@
+---
+- name: Install pipenv
+  ansible.builtin.pip:
+    name: "pipenv=={{ pipenv_version }}"
+    virtualenv: "{{ python_venv_dir }}"
+    virtualenv_command: 'python3 -m venv'


### PR DESCRIPTION
## Summary

- Adds an `ensure-pipenv` role that installs a pinned version of pipenv
  into the shared Python venv (`python_venv_dir`, default `/tmp`)
- Designed to run after `ensure-pip`, which sets up the venv
- Pipenv version is pinned with a renovate annotation and the role's
  defaults file is added to the `regexManagers` fileMatch list in
  `renovate.json` so updates are tracked automatically

## Usage

```yaml
roles:
  - ensure-pip
  - ensure-pipenv
```

Then invoke pipenv as `{{ python_venv_dir }}/bin/pipenv`.

AI-assisted: Claude Code