### PR TITLE
devstack: bump to supported release

### DIFF
--- a/roles/devstack/defaults/main.yml
+++ b/roles/devstack/defaults/main.yml
@@ -3,7 +3,7 @@
 zuul_work_dir: "{{ zuul.project.src_dir }}"
 
 # OpenStack release to use
-devstack_release: "stable/2024.2"
+devstack_release: "stable/2025.1"
 
 # Password for services, rabbitmq, database, ..
 devstack_password: password


### PR DESCRIPTION
stable/2024.2 is EOL, use stable/2025.1 instead