### PR TITLE
Fix project-board automation for fork PRs

### DIFF
--- a/.github/workflows/add-to-project.yml
+++ b/.github/workflows/add-to-project.yml
@@ -4,7 +4,7 @@ on:
   issues:
     types:
       - opened
-  pull_request:
+  pull_request_target:
     types:
       - opened
 
@@ -13,4 +13,5 @@ permissions: read-all
 jobs:
   add-to-project-boards:
     uses: osism/.github/.github/workflows/add-to-project.yml@main
-    secrets: inherit
+    secrets:
+      ADD_TO_PROJECT_PAT: ${{ secrets.ADD_TO_PROJECT_PAT }}


### PR DESCRIPTION
Fork PRs trigger the `pull_request` event, which GitHub deliberately
runs without access to secrets. `ADD_TO_PROJECT_PAT` is therefore empty and
`actions/add-to-project` fails with a missing github-token.

`pull_request_target` runs in the base-repository context where secrets are
available. It is safe here because this workflow never checks out or executes
PR code — it only calls `actions/add-to-project`.

While here, hand over only the required `ADD_TO_PROJECT_PAT` secret to the
reusable workflow instead of exposing all repository and organization secrets
via `secrets: inherit`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)